### PR TITLE
Added pagers / tokenised fetch.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='perimeterator',
-    version='0.1.0',  # TODO: Single source this from bagger.version.VERSION
+    version='0.2.0',  # TODO: Single source this.
     description='Continuous AWS Perimeter Monitoring',
     author='Peter Adkins',
     author_email='peter.adkins@kernelpicnic.net',

--- a/src/enumerator.py
+++ b/src/enumerator.py
@@ -40,10 +40,10 @@ def lambda_handler(event, context):
     # Get configurable options from environment variables.
     regions = os.getenv("ENUMERATOR_REGIONS", "us-west-2").split(",")
     sqs_queue = os.getenv("ENUMERATOR_SQS_QUEUE", None)
-    logger.info("Configured results SQS queue is %s", sqs_queue,)
+    logger.info("Configured results SQS queue is %s", sqs_queue)
     logger.info(
         "Configured regions for resource enumeration are %s",
-        ", ".join(regions),
+        ", ".join(regions)
     )
 
     # Setup the SQS dispatcher for submission of addresses to scanners.
@@ -60,13 +60,13 @@ def lambda_handler(event, context):
             try:
                 # Ensure a handler exists for this type of resource.
                 hndl = getattr(perimeterator.enumerator, module).Enumerator(
-                    region=region,
+                    region=region
                 )
             except AttributeError as err:
                 logger.error(
                     "Handler for %s resources not found, skipping: %s",
                     module,
-                    err,
+                    err
                 )
                 continue
 
@@ -74,7 +74,7 @@ def lambda_handler(event, context):
             logger.info(
                 "Submitting %s resources in %s for processing",
                 module,
-                region,
+                region
             )
             queue.dispatch(account, hndl.get())
 

--- a/src/perimeterator/enumerator/ec2.py
+++ b/src/perimeterator/enumerator/ec2.py
@@ -19,52 +19,71 @@ class Enumerator(object):
     def get(self):
         ''' Attempt to get all Public IPs from EC2 instances. '''
         resources = []
+        filters = [
+            {
+                "Name": "instance-state-name",
+                "Values": [
+                    "pending",
+                    "running",
+                ],
+            }
+        ]
 
-        # Ensure that all IPs attached to running or pending instances, are
+        # Ensure that all IPs attached to running or pending instances are
         # accounted for.
-        #
-        # TODO: NextToken
-        candidates = self.client.describe_instances(
-            Filters=[
-                {
-                    "Name": "instance-state-name",
-                    "Values": [
-                        "pending",
-                        "running",
-                    ],
-                }
-            ]
-        )
-
-        # A reservation can contain one or more instances
-        for reservation in candidates["Reservations"]:
-            self.logger.debug(
-                "Inspecting reservation %s", reservation["ReservationId"],
-            )
-            for instance in reservation["Instances"]:
-                self.logger.debug(
-                    "Inspecting instance %s", instance["InstanceId"],
+        next_token = ''
+        while next_token is not None:
+            if next_token:
+                candidates = self.client.describe_instances(
+                    Filters=filters,
+                    NextToken=next_token
                 )
-                # An instance can have multiple NICs.
-                addresses = []
-                for nic in instance["NetworkInterfaces"]:
-                    # A NIC can have multiple IPs.
-                    for ip in nic["PrivateIpAddresses"]:
-                        # An IP may not have an association if it is only an
-                        # RFC1918 address.
-                        if "Association" in ip and "PublicIp" in ip["Association"]:
-                            addresses.append(ip["Association"]["PublicIp"])
+            else:
+                candidates = self.client.describe_instances(
+                    Filters=filters
+                )
 
-                # We need to construct the EC2 instance ARN ourselves, as
-                # this isn't provided as part of the describe output.
-                resources.append({
-                    "service": self.SERVICE,
-                    "identifier": aws_ec2_arn(
-                        self.region,
-                        instance["InstanceId"]
-                    ),
-                    "addresses": addresses,
-                })
+            # Check if we need to continue paging.
+            if "NextToken" in candidates:
+                self.logger.debug(
+                    "'NextToken' found, additional page of results to fetch"
+                )
+                next_token = candidates["NextToken"]
+            else:
+                next_token = None
+
+            # A reservation can contain one or more instances
+            for reservation in candidates["Reservations"]:
+                self.logger.info(
+                    "Inspecting reservation %s",
+                    reservation["ReservationId"]
+                )
+                for instance in reservation["Instances"]:
+                    self.logger.info(
+                        "Inspecting instance %s", instance["InstanceId"]
+                    )
+                    # An instance can have multiple NICs.
+                    addresses = []
+                    for nic in instance["NetworkInterfaces"]:
+                        # A NIC can have multiple IPs.
+                        for ip in nic["PrivateIpAddresses"]:
+                            # An IP may not have an association if it is only
+                            # an RFC1918 address.
+                            if "Association" in ip and "PublicIp" in ip["Association"]:
+                                addresses.append(
+                                    ip["Association"]["PublicIp"]
+                                )
+
+                    # We need to construct the EC2 instance ARN ourselves, as
+                    # this isn't provided as part of the describe output.
+                    resources.append({
+                        "service": self.SERVICE,
+                        "identifier": aws_ec2_arn(
+                            self.region,
+                            instance["InstanceId"]
+                        ),
+                        "addresses": addresses,
+                    })
 
         self.logger.info("Got IPs for %s resources", len(resources))
         return resources

--- a/src/perimeterator/enumerator/elbv2.py
+++ b/src/perimeterator/enumerator/elbv2.py
@@ -20,40 +20,63 @@ class Enumerator(object):
         ''' Attempt to get all Public IPs from ELBv2 instances. '''
         resources = []
 
-        # TODO: NextMarker
-        candidates = self.client.describe_load_balancers()
-
-        # For some odd reason the AWS API doesn't appear to allow a filter
-        # on describe operations for ELBs, so we'll have to filter manually.
-        for elb in candidates["LoadBalancers"]:
-            self.logger.debug(
-                "Inspecting ELBv2 instance %s", elb["LoadBalancerArn"],
-            )
-            if elb["Scheme"] != "internet-facing":
-                self.logger.debug("ELBv2 instance is not internet facing")
-                continue
-
-            # If a network load balancer, IPs will be present in the describe
-            # output. If not, then we'll need to resolve the DNS name to get
-            # the current LB IPs.
-            if "LoadBalancerAddresses" in elb["AvailabilityZones"][0]:
-                addresses = []
-                for az in elb["AvailabilityZones"]:
-                    # Each AZ has an associated IP allocation.
-                    for address in az["LoadBalancerAddresses"]:
-                        addresses.append(address["IpAddress"])
-
-                resources.append({
-                    "service": self.SERVICE,
-                    "identifier": elb["LoadBalancerArn"],
-                    "addresses": addresses,
-                })
+        # Iterate over results until AWS no longer returns a 'NextMarker' in
+        # order to ensure all results are retrieved.
+        marker = ''
+        while marker is not None:
+            # Unfortunately, Marker=None or Marker='' is invalid for this API
+            # call, so it looks like we can't just set this to a None value,
+            # or use a ternary here.
+            if marker:
+                candidates = self.client.describe_load_balancers(
+                    Marker=marker
+                )
             else:
-                resources.append({
-                    "service": self.SERVICE,
-                    "identifier": elb["LoadBalancerArn"],
-                    "addresses": dns_lookup(elb["DNSName"]),
-                })
+                candidates = self.client.describe_load_balancers()
+
+            # Check if we need to continue paging.
+            if "NextMarker" in candidates:
+                self.logger.debug(
+                    "'NextMarker' found, additional page of results to fetch"
+                )
+                marker = candidates["NextMarker"]
+            else:
+                marker = None
+
+            # For some odd reason the AWS API doesn't appear to allow a
+            # filter on describe operations for ELBs, so we'll have to filter
+            # manually.
+            for elb in candidates["LoadBalancers"]:
+                self.logger.debug(
+                    "Inspecting ELBv2 instance %s", elb["LoadBalancerArn"],
+                )
+                if elb["Scheme"] != "internet-facing":
+                    self.logger.debug(
+                        "ELBv2 instance is not internet facing"
+                    )
+                    continue
+
+                # If a network load balancer, IPs will be present in the
+                # describe output. If not, then we'll need to resolve the DNS
+                # name to get the current LB IPs.
+                if "LoadBalancerAddresses" in elb["AvailabilityZones"][0]:
+                    addresses = []
+                    for az in elb["AvailabilityZones"]:
+                        # Each AZ has an associated IP allocation.
+                        for address in az["LoadBalancerAddresses"]:
+                            addresses.append(address["IpAddress"])
+
+                    resources.append({
+                        "service": self.SERVICE,
+                        "identifier": elb["LoadBalancerArn"],
+                        "addresses": addresses,
+                    })
+                else:
+                    resources.append({
+                        "service": self.SERVICE,
+                        "identifier": elb["LoadBalancerArn"],
+                        "addresses": dns_lookup(elb["DNSName"]),
+                    })
 
         self.logger.info("Got IPs for %s resources", len(resources))
         return resources

--- a/src/perimeterator/enumerator/rds.py
+++ b/src/perimeterator/enumerator/rds.py
@@ -22,27 +22,55 @@ class Enumerator(object):
 
         # Once again, the AWS API doesn't appear to allow filtering by RDS
         # instances where PubliclyAccessible is True. As a result, we'll
-        # need to do this manually.
-        #
-        # TODO: NextMarker
-        candidates = self.client.describe_db_instances()
+        # need to do this manually
+        marker = ''
+        while marker is not None:
+            if marker:
+                candidates = self.client.describe_db_instances(Marker=marker)
+            else:
+                candidates = self.client.describe_db_instances()
 
-        for rds in candidates["DBInstances"]:
-            self.logger.debug(
-                "Inspecting RDS instance %s", rds["DBInstanceIdentifier"],
-            )
-            if not rds["PubliclyAccessible"]:
-                self.logger.debug("RDS instance is not internet facing")
-                continue
+            # Check if we need to continue paging.
+            if "Marker" in candidates:
+                self.logger.debug(
+                    "'Marker' found, additional page of results to fetch"
+                )
+                marker = candidates["Marker"]
+            else:
+                marker = None
 
-            # Lookup the DNS name for this ELB to get the current IPs. We're
-            # ignoring the configured port for the time being, although this
-            # could present a trivial optimisation for scanning speed up.
-            resources.append({
-                "service": self.SERVICE,
-                "identifier": rds["DBInstanceArn"],
-                "addresses": dns_lookup(rds["Endpoint"]["Address"]),
-            })
+            for rds in candidates["DBInstances"]:
+                # Skip instances still being created as they may not yet have
+                # endpoints created / generated.
+                if rds["DBInstanceStatus"] == "creating":
+                    self.logger.debug(
+                        "Skipping instance as it's still being provisioned"
+                    )
+                    continue
+
+                self.logger.debug(
+                    "Inspecting RDS instance %s",
+                    rds["DBInstanceIdentifier"]
+                )
+                if not rds["PubliclyAccessible"]:
+                    self.logger.debug("RDS instance is not internet facing")
+                    continue
+
+                # Lookup the DNS name for this ELB to get the current IPs.
+                # We're ignoring the configured port for the time being,
+                # although this could present a trivial optimisation for
+                # scanning speed up.
+                try:
+                    resources.append({
+                        "service": self.SERVICE,
+                        "identifier": rds["DBInstanceArn"],
+                        "addresses": dns_lookup(rds["Endpoint"]["Address"]),
+                    })
+                except KeyError:
+                    self.logger.warning(
+                        "Skipping RDS instance %s due to error when enumerating endpoints",
+                        rds["DBInstanceArn"]
+                    )
 
         self.logger.info("Got IPs for %s resources", len(resources))
         return resources


### PR DESCRIPTION
## Overview

This PR adds support for tokenised fetching of paged results. This is required in cases where a large number of resources are returned by the respective AWS APIs.

Unfortunately APIs between AWS services appear to differ in both naming and permitted values which limits the ability to centralise some of this logic. As an example, the EC2 API calls the page 'marker' a Token, whereas the ELB APIs refer to this value as a 'Marker'.

Further to this, some API calls - such as EC2 `describe_instances` - permit an empty string or None value for `NextToken`. However, the ELB API does not appear to support this, instead raising a validataion error. This further complicates centralisation of this logic.

As a result of the above, all logic related to paging is kept in the respective enumerator module.