### PR TITLE
[0.3.0] Added Elasticsearch Service support. Bug fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Change Log
+
+The following list provides a brief overview of all features, bug fixes, and
+breaking changes as part of Perimeterator releases.
+
+## 0.3.0
+
+### 🤘Features
+
+* Adds AWS Elasticsearch Service support.
+* Single sourced versioning (`perimeterator.__version__`).
+* Bumped `boto3` version to latest.
+
+### 🐛Bug Fixes
+
+* Fixed broken paths to `scripts` in `setup.py`.
+* Documentation update to indicate first `enumerator` run may need to be run
+  manually, or it could take 24-hours for the first run to be executed. This
+  is due to the `rate(24 hours)` CloudWatch Events schedule.
+
+### 💥Breaking Changes
+
+* Nmap scanner now defaults to TCP only scans to greatly speed up scanning.
+* Changed installation paths inside `scanner` container. However, as the
+  container entrypoint was updated to reflect new paths, no impact should be
+  seen for the vast majority of users.
+
+## 0.2.0
+
+### 🤘Features
+
+* Added paging to enumerators in order to support accounts with a large
+  number of resources.
+
+### 🐛Bug Fixes
+
+* N/A
+
+### 💥Breaking Changes
+
+* N/A
+
+## 0.1.0
+
+### 🤘Features
+
+* Initial Release.
+
+### 🐛Bug Fixes
+
+* N/A
+
+### 💥Breaking Changes
+
+* N/A

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && \
     setcap cap_net_raw+ep /usr/bin/nmap
 
 # Install Perimeterator sources into the container.
-COPY --chown=perimeterator ./src/ /opt/perimeterator/
+RUN mkdir -p /opt/perimeterator/src
+COPY --chown=perimeterator ./src /opt/perimeterator/src
 COPY --chown=perimeterator ./setup.* /opt/perimeterator/
 
 # Install perimterator.
@@ -30,4 +31,4 @@ RUN pip3 install . && \
 
 # Kick off the monitor as soon as the container starts (by default).
 USER perimeterator
-ENTRYPOINT [ "python3", "/opt/perimeterator/scanner.py" ]
+ENTRYPOINT [ "python3", "/opt/perimeterator/src/scanner.py" ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently, the following AWS resource types are supported:
 * ELB
 * ELBv2
 * RDS
+* ES
 
 All communication between Perimeterator components occurs asynchronously
 through the use of AWS SQS queues.

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
+import os
 from setuptools import find_packages, setup
+
+# Source the version from the package.
+__version__ = 'Unknown'
+exec(open('src/perimeterator/version.py').read())
 
 setup(
     name='perimeterator',
-    version='0.2.0',  # TODO: Single source this.
+    version=__version__,
     description='Continuous AWS Perimeter Monitoring',
     author='Peter Adkins',
     author_email='peter.adkins@kernelpicnic.net',
@@ -17,8 +22,8 @@ setup(
         'perimeterator': 'src/perimeterator',
     },
     scripts=[
-        'enumerator.py',
-        'scanner.py',
+        'src/enumerator.py',
+        'src/scanner.py',
     ],
     setup_requires=[
         'pytest-runner',
@@ -28,6 +33,6 @@ setup(
         'pytest-cov',
     ],
     install_requires=[
-        'boto3==1.9.108'
+        'boto3==1.9.204'
     ]
 )

--- a/src/enumerator.py
+++ b/src/enumerator.py
@@ -17,6 +17,7 @@ MODULES = [
     'ec2',
     'elb',
     'elbv2',
+    'es',
 ]
 
 

--- a/src/perimeterator/__init__.py
+++ b/src/perimeterator/__init__.py
@@ -4,3 +4,6 @@ from perimeterator import helper      # noqa: F401
 from perimeterator import scanner     # noqa: F401
 from perimeterator import enumerator  # noqa: F401
 from perimeterator import dispatcher  # noqa: F401
+
+# Expose our version number somewhere expected.
+from perimeterator.version import __version__

--- a/src/perimeterator/enumerator/__init__.py
+++ b/src/perimeterator/enumerator/__init__.py
@@ -4,3 +4,4 @@ from perimeterator.enumerator import ec2     # noqa: F401
 from perimeterator.enumerator import elb     # noqa: F401
 from perimeterator.enumerator import elbv2   # noqa: F401
 from perimeterator.enumerator import rds     # noqa: F401
+from perimeterator.enumerator import es      # noqa: F401

--- a/src/perimeterator/enumerator/es.py
+++ b/src/perimeterator/enumerator/es.py
@@ -1,0 +1,68 @@
+''' Perimeterator - Enumerator for AWS Elasticsearch instances. '''
+
+import logging
+import boto3
+
+from perimeterator.helper import dns_lookup
+
+
+class Enumerator(object):
+    ''' Perimeterator - Enumerator for AWS Elasticsearch instances. '''
+    # Required for Boto and reporting.
+    SERVICE = 'es'
+
+    def __init__(self, region):
+        self.logger = logging.getLogger(__name__)
+        self.region = region
+        self.client = boto3.client(self.SERVICE, region_name=region)
+
+    def get(self):
+        ''' Attempt to get IPs associated with Elasticsearch endpoints. '''
+        resources = []
+
+        # Get a list of all domains and then manually prune it based on
+        # whether the domains are created, being deleted, etc.
+        candidates = self.client.list_domain_names()
+
+        for es in candidates["DomainNames"]:
+            # Query for data about this domain based on the enumerated name.
+            domain = self.client.describe_elasticsearch_domain(
+                DomainName=es["DomainName"]
+            )
+            
+            self.logger.debug("Inspecting ES domain %s", es["DomainName"])
+            if domain["DomainStatus"]["Created"] == False:
+                self.logger.debug(
+                    "Skipping ES domain as it's still being provisioned"
+                )
+                continue
+
+            if domain["DomainStatus"]["Deleted"] == True:
+                self.logger.debug(
+                    "Skipping ES domain as it's currently being deleted"
+                )
+                continue
+
+            # Skip VPC endpoints.
+            if "Endpoints" in domain["DomainStatus"]:
+                self.logger.debug(
+                    "Skipping ES domain as it has VPC only endpoints"
+                )
+                continue
+
+            # Lookup the DNS name to get the current IPs.
+            try:
+                resources.append({
+                    "service": self.SERVICE,
+                    "identifier": domain["DomainStatus"]["ARN"],
+                    "addresses": dns_lookup(
+                        domain["DomainStatus"]["Endpoint"]
+                    ),
+                })
+            except KeyError:
+                self.logger.warning(
+                    "Skipping ES domain due to error when enumerating endpoints",
+                )
+
+        self.logger.info("Got IPs for %s resources", len(resources))
+        return resources

--- a/src/perimeterator/enumerator/rds.py
+++ b/src/perimeterator/enumerator/rds.py
@@ -56,10 +56,9 @@ class Enumerator(object):
                     self.logger.debug("RDS instance is not internet facing")
                     continue
 
-                # Lookup the DNS name for this ELB to get the current IPs.
-                # We're ignoring the configured port for the time being,
-                # although this could present a trivial optimisation for
-                # scanning speed up.
+                # Lookup the DNS name to get the current IPs. We're ignoring
+                # the configured port for the time being, although this could
+                # present a trivial optimisation for scanning speed up.
                 try:
                     resources.append({
                         "service": self.SERVICE,

--- a/src/perimeterator/scanner/nmap.py
+++ b/src/perimeterator/scanner/nmap.py
@@ -80,7 +80,6 @@ def run(arn, targets, timeout=300):
                         "-T4",              # Set timing to "Normal".
                         "-Pn",              # Treat hosts as online.
                         "-sT",              # Connect() scan.
-                        "-sU",              # UDP scan.
                     ],
                     check=True,
                     shell=False,

--- a/src/perimeterator/version.py
+++ b/src/perimeterator/version.py
@@ -1,0 +1,3 @@
+''' Perimeterator version information. '''
+
+__version__ = '0.3.0'

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -47,9 +47,18 @@ To deploy simply follow the following steps:
 7. Enjoy your ☕️ / 🍺 / 🥃 / 🍚 while you wait for the deployment to finish.
 8. Use the output AWS IAM keys to deploy a scanner.
 
-Please be aware that the Terraform configs will automatically invoke the
-function after execution. This has been done to trigger an immediate run, as
-the default execution interval is 24-hours.
+Please be aware that the deployed `enumerator` Lambda function will only
+execute every 24 hours by default, and it may take some time for the first
+run to be triggered by the CloudWatch Events rule. Logs can be found in the
+CloudWatch console which can be used to monitor the status of `enumerator`
+runs.
+
+Invocation can also be performed manually after - if required - with the
+following AWS CLI command:
+
+```
+aws lambda invoke --function-name perimeterator-enumerator /dev/null
+```
 
 ## Logs
 
@@ -60,6 +69,6 @@ group, easily accessible from CloudWatch Logs in the AWS console.
 ## Customisation
 
 In order to customise the deployment - such as changing the frequency of the
-Enumerator run, or region(s) on which it will enumerate resourrces - please
+Enumerator run, or region(s) on which it will enumerate resources - please
 see the `variables.tf` file, and the comments associated with the respective
 variable you would like to change.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -191,6 +191,16 @@ resource "aws_iam_policy" "describe" {
       "Effect": "Allow",
       "Action": "rds:DescribeDBInstances",
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "es:ListDomainNames",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "es:DescribeElasticsearchDomain",
+      "Resource": "*"
     }
   ]
 }
@@ -253,10 +263,3 @@ resource "aws_lambda_permission" "invoker" {
   statement_id  = "AllowExecutionFromCloudWatch"
   function_name = "${aws_lambda_function.enumerator.function_name}"
 }
-
-// Finally, immediately invoke the function to trigger an enumerate operation.
-// TODO: Disabled due to order of operations issue (?)
-// data "aws_lambda_invocation" "enumerate" {
-//  function_name = "${aws_lambda_function.enumerator.function_name}"
-//  input         = ""
-// }


### PR DESCRIPTION
### 🤘Features

* Adds AWS Elasticsearch Service support.
* Single sourced versioning (`perimeterator.__version__`).
* Bumped `boto3` version to latest.

### 🐛Bug Fixes

* Fixed broken paths to `scripts` in `setup.py`.
* Documentation update to indicate first `enumerator` run may need to be run manually, or it could take 24-hours for the first run to be executed. This is due to the `rate(24 hours)` CloudWatch Events schedule.

### 💥Breaking Changes

* Nmap scanner now defaults to TCP only scans to greatly speed up scanning.
* Changed installation paths inside `scanner` container. However, as the container entrypoint was updated to reflect new paths, no impact should be seen for the vast majority of users.
